### PR TITLE
Add the init_config script

### DIFF
--- a/bin/init_config
+++ b/bin/init_config
@@ -1,13 +1,15 @@
 #!/usr/bin/env ruby
 
+require 'fileutils'
+
 Dir.glob("config/*.yml.example").each do |example_file|
   target_file = example_file[0..-9]
 
   if File.exist? target_file
     puts "Ignore the #{target_file}"
   else
-    command = "/bin/cp #{example_file} #{target_file}"
-    puts command, `#{command}`
+    FileUtils.cp example_file, target_file
+    puts "cp #{example_file} #{target_file}"
   end
 end
 

--- a/doc/install/development.md
+++ b/doc/install/development.md
@@ -108,7 +108,7 @@ Insert the following lines into your bitcoin.conf, and replce with your username
 
 ##### Prepare configure files:
 
-    script/init_config
+    bin/init_config
 
 ##### Setup reCAPTCHA/Pusher:
 


### PR DESCRIPTION
Instead of copying every config file when setup the environment.
Add a init_config script to do it automatically.
