### PR TITLE
Add the lang in params when doing request tests.

### DIFF
--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -6,7 +6,7 @@ describe 'Sign in' do
 
   it 'allows a user to sign in with email, password' do
     signin identity
-    expect(current_path).to eq(settings_path)
+    expect(URI(current_path).path).to eq(URI(settings_path).path)
   end
 
   it "sends notification email after user sign in" do

--- a/spec/features/withdraw_spec.rb
+++ b/spec/features/withdraw_spec.rb
@@ -91,7 +91,7 @@ describe 'withdraw' do
     visit new_withdraws_bank_path
 
     submit_bank_withdraw_request 800
-    expect(current_path).to eq(withdraws_banks_path)
+    expect(URI(current_path).path).to eq(URI(withdraws_banks_path).path)
     expect(page).to have_text(I18n.t('activerecord.errors.models.withdraws/bank.attributes.sum.poor'))
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,6 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
-I18n.locale = :en
-
 Capybara.register_driver :poltergeist do |app|
   options = {:js_errors => false, :debug => false, :logger => nil, :phantomjs_logger => nil}
   Capybara::Poltergeist::Driver.new(app, options)

--- a/spec/support/locale.rb
+++ b/spec/support/locale.rb
@@ -1,0 +1,11 @@
+class ActionView::TestCase::TestController
+  def default_url_options(options={})
+    { :lang => :en }
+  end
+end
+
+class ActionDispatch::Routing::RouteSet
+  def default_url_options(options={})
+    { :lang => :en }
+  end
+end

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,7 +1,7 @@
 def login(identity, otp: nil, password: nil)
   visit root_path
   click_on I18n.t('header.signin')
-  expect(current_path).to eq(signin_path)
+  expect(URI(current_path).path).to eq(URI(signin_path).path)
 
   within 'form#new_identity' do
     fill_in 'identity_email', with: identity.email


### PR DESCRIPTION
Problem description: Before we set the I18n.locale to :en in our test env. But in the application controller we also set the language
by the params or browser. So if we run request test in different language
environment, the locale will be set differently. When the environment
is not English, there will be some failures when we try to click links
or check content by words in Carpybara.

Solution: Removing the dependency to the running env. We'd better set
the lang for every request in our test.
