### PR TITLE
Move therubyracer to production group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'slim-rails'
 gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier'
-gem 'therubyracer'
 gem "jquery-rails"
 gem 'bootstrap-sass'
 gem 'bootstrap-wysihtml5-rails'
@@ -94,6 +93,10 @@ group :test do
   gem 'launchy'
   gem 'selenium-webdriver'
   gem 'poltergeist'
+end
+
+group :production do
+  gem "therubyracer"
 end
 
 gem 'unicorn'

--- a/doc/setup-ubuntu.md
+++ b/doc/setup-ubuntu.md
@@ -10,7 +10,8 @@ Setup on Ubuntu 14.04 LTS
 5. Install [RabbitMQ](https://www.rabbitmq.com/)
 6. Install [Bitcoind](https://en.bitcoin.it/wiki/Bitcoind)
 7. Install [PhantomJS](http://phantomjs.org/)
-7. Configure Peatio
+8. Install a JavaScript Runtime
+9. Configure Peatio
 
 ### 1. Setup deploy user
 
@@ -122,7 +123,13 @@ Peatio uses Capybara with PhantomJS to do the feature tests, so if you want to r
     git checkout 1.9
     ./build.sh
 
-### 8. Configure Peatio
+### 8. Install a JavaScript Runtime
+
+A JavaScript Runtime is needed for Asset Pipeline to work. Any runtime will do but Node.js is recommended.
+
+    sudo apt-get install nodejs
+
+### 9. Configure Peatio
 
 **Clone the project**
 


### PR DESCRIPTION
It's always been a pain in the ass to build `therubyracer` and `libv8`. Not only do we have many difficulties to build successfully (it fails on OS X 10.10), it also takes long to build.

If we **only** use it for asset pipeline, then we could remove it if we have a JavaScript runtime such as Node.js installed.

Move it to `production` group for now so it doesn't affect production server.

If we can confirm that:
- do not use it anywhere except asset pipeline
- have JavaScript runtime on production server

Then perhaps we'd happily delete it from `production` group too.
