### PR TITLE
Fix member identity nil error

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -157,7 +157,8 @@ class Member < ActiveRecord::Base
   end
 
   def identity
-    Identity.find(authentications.find_by_provider('identity').uid)
+    authentication = authentications.find_by(provider: 'identity')
+    authentication ? Identity.find(authentication.uid) : nil
   end
 
   def send_activation

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -110,9 +110,7 @@ describe Member do
   describe "#identity" do
     it "should not raise but return nil when authentication is not found" do
       member = create(:member)
-      expect {
-        member.identity
-      }.to_not raise_error
+      expect(member.identity).to be_nil
     end
   end
 


### PR DESCRIPTION
What's confusing me is, member has a `identity_id`, so do we have some property override here?
