### PR TITLE
Update deploy-ubuntu.md

### DIFF
--- a/doc/deploy-ubuntu.md
+++ b/doc/deploy-ubuntu.md
@@ -122,7 +122,7 @@ Add HTTPS support to APT
 
     sudo apt-get install apt-transport-https ca-certificates
 
-Add the passenger repository
+Add the passenger repository. Note that this only works for Ubuntu 14.04. For other versions of Ubuntu, you have to add the appropriate repository according to Section 2.3.1 of this [link](https://www.phusionpassenger.com/documentation/Users%20guide%20Nginx.html).
 
     sudo add-apt-repository 'deb https://oss-binaries.phusionpassenger.com/apt/passenger trusty main'
     sudo apt-get update


### PR DESCRIPTION
Added clarification for benefit of those who are following this guide using Ubuntu 12.04 or Ubuntu 10.04. When installing nginx-extras, the command sudo add-apt-repository 'deb https://oss-binaries.phusionpassenger.com/apt/passenger trusty main' is specific to the version of Ubuntu. For instance, under Ubuntu 12.04, the command should be: sudo add-apt-repository 'deb https://oss-binaries.phusionpassenger.com/apt/passenger precise main'
