### PR TITLE
Remove constraint require

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,3 @@
-require 'market_constraint'
-require 'whitelist_constraint'
-
 Rails.application.eager_load! if Rails.env.development?
 
 class ActionDispatch::Routing::Mapper


### PR DESCRIPTION
Rails.root/lib is in autoload paths, no need to require them.
