### PR TITLE
Change bitcoind rpc port to 8332

### DIFF
--- a/config/currencies.yml.example
+++ b/config/currencies.yml.example
@@ -13,7 +13,7 @@
   key: satoshi
   code: btc
   coin: true
-  rpc: http://username:password@127.0.0.1:18332
+  rpc: http://username:password@127.0.0.1:8332
   blockchain: https://blockchain.info/tx/#{txid}
   address_url: https://blockchain.info/address/#{address}
   assets:


### PR DESCRIPTION
Had to change port from `18332` to `8332` from the example yam to make `CoinRPC` work properly.

(but I'm not sure if this is the correct default value, please ignore this PR if that's not the case).
