### PR TITLE
camelize controller name in deposit/withdraw templates

### DIFF
--- a/lib/generators/deposit/templates/controller.rb.erb
+++ b/lib/generators/deposit/templates/controller.rb.erb
@@ -1,6 +1,6 @@
 module Private
   module Deposits
-    class <%= name.pluralize %>Controller < ::Private::Deposits::BaseController
+    class <%= name.camelize.pluralize %>Controller < ::Private::Deposits::BaseController
       include ::Deposits::CtrlCoinable
     end
   end

--- a/lib/generators/withdraw/templates/controller.rb.erb
+++ b/lib/generators/withdraw/templates/controller.rb.erb
@@ -1,6 +1,6 @@
 module Private
   module Withdraws
-    class <%= name.pluralize %>Controller < ::Private::Withdraws::BaseController
+    class <%= name.camelize.pluralize %>Controller < ::Private::Withdraws::BaseController
       include ::Withdraws::CtrlCoinable
     end
   end


### PR DESCRIPTION
when you generate a new coin template, lowercase words will cause a error.
