### PR TITLE
Add missing translation (email not-member) for reset password form

### DIFF
--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -158,7 +158,7 @@ en:
             base:
               too_soon: Visit too soon
             email:
-              match: Invalid Sign in Email
+              not-member: Invalid Email
               match: Invalid Sign in Email
             password:
               invalid: Invalid Password


### PR DESCRIPTION
Reported in #143
