### PR TITLE
Remove annotate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,6 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'rspec-rails'
   gem 'byebug'
-  gem "annotate", '~> 2.5.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,6 @@ GEM
     amqp (1.3.0)
       amq-protocol (>= 1.9.2)
       eventmachine
-    annotate (2.5.0)
-      rake
     arel (4.0.2)
     atomic (1.1.16)
     awesome_print (1.2.0)
@@ -418,7 +416,6 @@ DEPENDENCIES
   active_hash
   acts-as-taggable-on
   amqp (~> 1.3.0)
-  annotate (~> 2.5.0)
   bcrypt-ruby (~> 3.1.2)
   better_errors
   binding_of_caller

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: accounts
-#
-#  id         :integer          not null, primary key
-#  member_id  :integer
-#  currency   :integer
-#  balance    :decimal(32, 16)
-#  locked     :decimal(32, 16)
-#  created_at :datetime
-#  updated_at :datetime
-#  in         :decimal(32, 16)
-#  out        :decimal(32, 16)
-#
-
 class Account < ActiveRecord::Base
   include Currencible
 

--- a/app/models/account_version.rb
+++ b/app/models/account_version.rb
@@ -1,23 +1,3 @@
-# == Schema Information
-#
-# Table name: account_versions
-#
-#  id              :integer          not null, primary key
-#  member_id       :integer
-#  account_id      :integer
-#  reason          :integer
-#  balance         :decimal(32, 16)
-#  locked          :decimal(32, 16)
-#  fee             :decimal(32, 16)
-#  amount          :decimal(32, 16)
-#  modifiable_id   :integer
-#  modifiable_type :string(255)
-#  created_at      :datetime
-#  updated_at      :datetime
-#  currency        :integer
-#  fun             :integer
-#
-
 class AccountVersion < ActiveRecord::Base
   include Currencible
 

--- a/app/models/activation.rb
+++ b/app/models/activation.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  expire_at  :datetime
-#  member_id  :integer
-#  is_used    :boolean
-#  type       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 class Activation < Token
 
   after_create :send_token

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,16 +1,3 @@
-# == Schema Information
-#
-# Table name: api_tokens
-#
-#  id              :integer          not null, primary key
-#  member_id       :integer          not null
-#  access_key      :string(50)       not null
-#  secret_key      :string(50)       not null
-#  created_at      :datetime
-#  updated_at      :datetime
-#  trusted_ip_list :string(255)
-#
-
 class APIToken < ActiveRecord::Base
 
   belongs_to :member

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,14 +1,3 @@
-# == Schema Information
-#
-# Table name: assets
-#
-#  id              :integer          not null, primary key
-#  type            :string(255)
-#  attachable_id   :integer
-#  attachable_type :string(255)
-#  file            :string(255)
-#
-
 class Asset < ActiveRecord::Base
   belongs_to :attachable, polymorphic: true
 

--- a/app/models/audit/audit_log.rb
+++ b/app/models/audit/audit_log.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: audit_logs
-#
-#  id             :integer          not null, primary key
-#  type           :string(255)
-#  operator_id    :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  auditable_id   :integer
-#  auditable_type :string(255)
-#  source_state   :string(255)
-#  target_state   :string(255)
-#
-
 module Audit
   class AuditLog < ActiveRecord::Base
     belongs_to :operator, class_name: 'Member', foreign_key: 'operator_id'

--- a/app/models/audit/transfer_audit_log.rb
+++ b/app/models/audit/transfer_audit_log.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: audit_logs
-#
-#  id             :integer          not null, primary key
-#  type           :string(255)
-#  operator_id    :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  auditable_id   :integer
-#  auditable_type :string(255)
-#  source_state   :string(255)
-#  target_state   :string(255)
-#
-
 module Audit
   class TransferAuditLog < AuditLog
 

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: authentications
-#
-#  id         :integer          not null, primary key
-#  provider   :string(255)
-#  uid        :string(255)
-#  token      :string(255)
-#  secret     :string(255)
-#  member_id  :integer
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 class Authentication < ActiveRecord::Base
   belongs_to :member
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: comments
-#
-#  id         :integer          not null, primary key
-#  content    :text
-#  author_id  :integer
-#  ticket_id  :integer
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 class Comment < ActiveRecord::Base
   after_commit :send_notification, on: [:create]
 

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -1,25 +1,3 @@
-# == Schema Information
-#
-# Table name: deposits
-#
-#  id         :integer          not null, primary key
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  txid       :string(255)
-#  state      :integer
-#  aasm_state :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  memo       :string(255)
-#  type       :string(255)
-#
-
 class Deposit < ActiveRecord::Base
   STATES = [:submitting, :cancelled, :submitted, :rejected, :accepted, :checked, :warning]
 

--- a/app/models/deposits/bank.rb
+++ b/app/models/deposits/bank.rb
@@ -1,25 +1,3 @@
-# == Schema Information
-#
-# Table name: deposits
-#
-#  id         :integer          not null, primary key
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  txid       :string(255)
-#  state      :integer
-#  aasm_state :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  memo       :string(255)
-#  type       :string(255)
-#
-
 module Deposits
   class Bank < ::Deposit
     include ::AasmAbsolutely

--- a/app/models/deposits/satoshi.rb
+++ b/app/models/deposits/satoshi.rb
@@ -1,25 +1,3 @@
-# == Schema Information
-#
-# Table name: deposits
-#
-#  id         :integer          not null, primary key
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  txid       :string(255)
-#  state      :integer
-#  aasm_state :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  memo       :string(255)
-#  type       :string(255)
-#
-
 module Deposits
   class Satoshi < ::Deposit
     include ::AasmAbsolutely

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: documents
-#
-#  id         :integer          not null, primary key
-#  key        :string(255)
-#  title      :string(255)
-#  body       :text
-#  is_auth    :boolean
-#  created_at :datetime
-#  updated_at :datetime
-#  desc       :text
-#  keywords   :text
-#
-
 class Document < ActiveRecord::Base
   TRANSLATABLE_ATTR = [:title, :desc, :keywords, :body]
   translates *TRANSLATABLE_ATTR

--- a/app/models/fund_source.rb
+++ b/app/models/fund_source.rb
@@ -1,19 +1,3 @@
-# == Schema Information
-#
-# Table name: fund_sources
-#
-#  id         :integer          not null, primary key
-#  member_id  :integer
-#  currency   :integer
-#  extra      :string(255)
-#  uid        :string(255)
-#  is_locked  :boolean          default(FALSE)
-#  created_at :datetime
-#  updated_at :datetime
-#  deleted_at :datetime
-#  bsb        :string(255)
-#
-
 class FundSource < ActiveRecord::Base
   include Currencible
 

--- a/app/models/id_document.rb
+++ b/app/models/id_document.rb
@@ -1,23 +1,3 @@
-# == Schema Information
-#
-# Table name: id_documents
-#
-#  id                 :integer          not null, primary key
-#  id_document_type   :integer
-#  name               :string(255)
-#  id_document_number :string(255)
-#  member_id          :integer
-#  created_at         :datetime
-#  updated_at         :datetime
-#  birth_date         :date
-#  address            :text
-#  city               :string(255)
-#  country            :string(255)
-#  zipcode            :string(255)
-#  id_bill_type       :integer
-#  aasm_state         :string(255)
-#
-
 class IdDocument < ActiveRecord::Base
   extend Enumerize
   include AASM

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,19 +1,3 @@
-# == Schema Information
-#
-# Table name: identities
-#
-#  id              :integer          not null, primary key
-#  email           :string(255)
-#  password_digest :string(255)
-#  is_active       :boolean
-#  retry_count     :integer
-#  is_locked       :boolean
-#  locked_at       :datetime
-#  last_verify_at  :datetime
-#  created_at      :datetime
-#  updated_at      :datetime
-#
-
 class Identity < OmniAuth::Identity::Models::ActiveRecord
   auth_key :email
   attr_accessor :old_password

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,25 +1,3 @@
-# == Schema Information
-#
-# Table name: members
-#
-#  id                    :integer          not null, primary key
-#  sn                    :string(255)
-#  display_name          :string(255)
-#  email                 :string(255)
-#  identity_id           :integer
-#  created_at            :datetime
-#  updated_at            :datetime
-#  state                 :integer
-#  activated             :boolean
-#  country_code          :integer
-#  phone_number          :string(255)
-#  phone_number_verified :boolean
-#  disabled              :boolean          default(FALSE)
-#  api_disabled          :boolean          default(FALSE)
-#  inviter_id            :integer
-#  referral_code_reward  :boolean          default(FALSE)
-#
-
 class Member < ActiveRecord::Base
   acts_as_taggable
   acts_as_reader

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: orders
-#
-#  id             :integer          not null, primary key
-#  bid            :integer
-#  ask            :integer
-#  currency       :integer
-#  price          :decimal(32, 16)
-#  volume         :decimal(32, 16)
-#  origin_volume  :decimal(32, 16)
-#  state          :integer
-#  done_at        :datetime
-#  type           :string(8)
-#  member_id      :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  sn             :string(255)
-#  source         :string(255)      not null
-#  ord_type       :string(10)
-#  locked         :decimal(32, 16)
-#  origin_locked  :decimal(32, 16)
-#  funds_received :decimal(32, 16)  default(0.0)
-#
-
 class Order < ActiveRecord::Base
   extend Enumerize
 

--- a/app/models/order_ask.rb
+++ b/app/models/order_ask.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: orders
-#
-#  id             :integer          not null, primary key
-#  bid            :integer
-#  ask            :integer
-#  currency       :integer
-#  price          :decimal(32, 16)
-#  volume         :decimal(32, 16)
-#  origin_volume  :decimal(32, 16)
-#  state          :integer
-#  done_at        :datetime
-#  type           :string(8)
-#  member_id      :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  sn             :string(255)
-#  source         :string(255)      not null
-#  ord_type       :string(10)
-#  locked         :decimal(32, 16)
-#  origin_locked  :decimal(32, 16)
-#  funds_received :decimal(32, 16)  default(0.0)
-#
-
 class OrderAsk < Order
 
   has_many :trades, foreign_key: 'ask_id'

--- a/app/models/order_bid.rb
+++ b/app/models/order_bid.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: orders
-#
-#  id             :integer          not null, primary key
-#  bid            :integer
-#  ask            :integer
-#  currency       :integer
-#  price          :decimal(32, 16)
-#  volume         :decimal(32, 16)
-#  origin_volume  :decimal(32, 16)
-#  state          :integer
-#  done_at        :datetime
-#  type           :string(8)
-#  member_id      :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  sn             :string(255)
-#  source         :string(255)      not null
-#  ord_type       :string(10)
-#  locked         :decimal(32, 16)
-#  origin_locked  :decimal(32, 16)
-#  funds_received :decimal(32, 16)  default(0.0)
-#
-
 class OrderBid < Order
 
   has_many :trades, foreign_key: 'bid_id'

--- a/app/models/partial_tree.rb
+++ b/app/models/partial_tree.rb
@@ -1,16 +1,3 @@
-# == Schema Information
-#
-# Table name: partial_trees
-#
-#  id         :integer          not null, primary key
-#  proof_id   :integer          not null
-#  account_id :integer          not null
-#  json       :text             not null
-#  created_at :datetime
-#  updated_at :datetime
-#  sum        :string(255)
-#
-
 class PartialTree < ActiveRecord::Base
 
   belongs_to :account

--- a/app/models/payment_address.rb
+++ b/app/models/payment_address.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: payment_addresses
-#
-#  id         :integer          not null, primary key
-#  account_id :integer
-#  address    :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  currency   :integer
-#
-
 class PaymentAddress < ActiveRecord::Base
   include Currencible
   belongs_to :account

--- a/app/models/payment_transaction.rb
+++ b/app/models/payment_transaction.rb
@@ -1,21 +1,3 @@
-# == Schema Information
-#
-# Table name: payment_transactions
-#
-#  id            :integer          not null, primary key
-#  txid          :string(255)
-#  amount        :decimal(32, 16)
-#  confirmations :integer
-#  address       :string(255)
-#  state         :integer
-#  aasm_state    :string(255)
-#  created_at    :datetime
-#  updated_at    :datetime
-#  receive_at    :datetime
-#  dont_at       :datetime
-#  currency      :integer
-#
-
 class PaymentTransaction < ActiveRecord::Base
   extend Enumerize
 

--- a/app/models/proof.rb
+++ b/app/models/proof.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: proofs
-#
-#  id         :integer          not null, primary key
-#  root       :string(255)
-#  currency   :integer
-#  ready      :boolean          default(FALSE)
-#  created_at :datetime
-#  updated_at :datetime
-#  sum        :string(255)
-#  addresses  :text
-#  balance    :string(30)
-#
-
 class Proof < ActiveRecord::Base
   include Currencible
 

--- a/app/models/reset_password.rb
+++ b/app/models/reset_password.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  expire_at  :datetime
-#  member_id  :integer
-#  is_used    :boolean
-#  type       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 class ResetPassword < Token
   attr_accessor :email
   attr_accessor :password

--- a/app/models/sms_token.rb
+++ b/app/models/sms_token.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  expire_at  :datetime
-#  member_id  :integer
-#  is_used    :boolean
-#  type       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 class SmsToken < Token
 
   VERIFICATION_CODE_LENGTH = 6

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,16 +1,3 @@
-# == Schema Information
-#
-# Table name: tickets
-#
-#  id         :integer          not null, primary key
-#  title      :string(255)
-#  content    :text
-#  aasm_state :string(255)
-#  author_id  :integer
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 class Ticket < ActiveRecord::Base
   include AASM
   include AASM::Locking

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  expire_at  :datetime
-#  member_id  :integer
-#  is_used    :boolean
-#  type       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 class Token < ActiveRecord::Base
   belongs_to :member
 

--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -1,21 +1,3 @@
-# == Schema Information
-#
-# Table name: trades
-#
-#  id            :integer          not null, primary key
-#  price         :decimal(32, 16)
-#  volume        :decimal(32, 16)
-#  ask_id        :integer
-#  bid_id        :integer
-#  trend         :integer
-#  currency      :integer
-#  created_at    :datetime
-#  updated_at    :datetime
-#  ask_member_id :integer
-#  bid_member_id :integer
-#  funds         :decimal(32, 16)
-#
-
 class Trade < ActiveRecord::Base
   extend ActiveHash::Associations::ActiveRecordExtensions
   ZERO = '0.0'.to_d

--- a/app/models/two_factor.rb
+++ b/app/models/two_factor.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: two_factors
-#
-#  id             :integer          not null, primary key
-#  member_id      :integer
-#  otp_secret     :string(255)
-#  last_verify_at :datetime
-#  activated      :boolean
-#  type           :string(255)
-#
-
 class TwoFactor < ActiveRecord::Base
   belongs_to :member
 

--- a/app/models/two_factor/app.rb
+++ b/app/models/two_factor/app.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: two_factors
-#
-#  id             :integer          not null, primary key
-#  member_id      :integer
-#  otp_secret     :string(255)
-#  last_verify_at :datetime
-#  activated      :boolean
-#  type           :string(255)
-#
-
 class TwoFactor::App < ::TwoFactor
 
   def verify(otp = nil)

--- a/app/models/two_factor/email.rb
+++ b/app/models/two_factor/email.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: two_factors
-#
-#  id             :integer          not null, primary key
-#  member_id      :integer
-#  otp_secret     :string(255)
-#  last_verify_at :datetime
-#  activated      :boolean
-#  type           :string(255)
-#
-
 class TwoFactor::Email < ::TwoFactor
 
 end

--- a/app/models/two_factor/sms.rb
+++ b/app/models/two_factor/sms.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: two_factors
-#
-#  id             :integer          not null, primary key
-#  member_id      :integer
-#  otp_secret     :string(255)
-#  last_verify_at :datetime
-#  activated      :boolean
-#  type           :string(255)
-#
-
 class TwoFactor::Sms < ::TwoFactor
   OTP_LENGTH = 6
 

--- a/app/models/two_factor/wechat.rb
+++ b/app/models/two_factor/wechat.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: two_factors
-#
-#  id             :integer          not null, primary key
-#  member_id      :integer
-#  otp_secret     :string(255)
-#  last_verify_at :datetime
-#  activated      :boolean
-#  type           :string(255)
-#
-
 class TwoFactor::Wechat < ::TwoFactor
 
 end

--- a/app/models/withdraw.rb
+++ b/app/models/withdraw.rb
@@ -1,26 +1,3 @@
-# == Schema Information
-#
-# Table name: withdraws
-#
-#  id         :integer          not null, primary key
-#  sn         :string(255)
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  txid       :string(255)
-#  aasm_state :string(255)
-#  sum        :decimal(32, 16)  default(0.0), not null
-#  type       :string(255)
-#  bsb        :string(255)
-#
-
 class Withdraw < ActiveRecord::Base
   STATES = [:submitting, :submitted, :rejected, :accepted, :suspect, :processing,
             :coin_ready, :coin_done, :done, :canceled, :almost_done, :failed]

--- a/app/models/withdraws/bank.rb
+++ b/app/models/withdraws/bank.rb
@@ -1,26 +1,3 @@
-# == Schema Information
-#
-# Table name: withdraws
-#
-#  id         :integer          not null, primary key
-#  sn         :string(255)
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  txid       :string(255)
-#  aasm_state :string(255)
-#  sum        :decimal(32, 16)  default(0.0), not null
-#  type       :string(255)
-#  bsb        :string(255)
-#
-
 module Withdraws
   class Bank < ::Withdraw
     include ::AasmAbsolutely

--- a/app/models/withdraws/satoshi.rb
+++ b/app/models/withdraws/satoshi.rb
@@ -1,26 +1,3 @@
-# == Schema Information
-#
-# Table name: withdraws
-#
-#  id         :integer          not null, primary key
-#  sn         :string(255)
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  txid       :string(255)
-#  aasm_state :string(255)
-#  sum        :decimal(32, 16)  default(0.0), not null
-#  type       :string(255)
-#  bsb        :string(255)
-#
-
 module Withdraws
   class Satoshi < ::Withdraw
     include ::AasmAbsolutely

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: accounts
-#
-#  id         :integer          not null, primary key
-#  member_id  :integer
-#  currency   :integer
-#  balance    :decimal(32, 16)
-#  locked     :decimal(32, 16)
-#  created_at :datetime
-#  updated_at :datetime
-#  in         :decimal(32, 16)
-#  out        :decimal(32, 16)
-#
-
 require 'spec_helper'
 
 describe Account do

--- a/spec/models/account_version_spec.rb
+++ b/spec/models/account_version_spec.rb
@@ -1,23 +1,3 @@
-# == Schema Information
-#
-# Table name: account_versions
-#
-#  id              :integer          not null, primary key
-#  member_id       :integer
-#  account_id      :integer
-#  reason          :integer
-#  balance         :decimal(32, 16)
-#  locked          :decimal(32, 16)
-#  fee             :decimal(32, 16)
-#  amount          :decimal(32, 16)
-#  modifiable_id   :integer
-#  modifiable_type :string(255)
-#  created_at      :datetime
-#  updated_at      :datetime
-#  currency        :integer
-#  fun             :integer
-#
-
 require 'spec_helper'
 
 describe AccountVersion do

--- a/spec/models/activation_spec.rb
+++ b/spec/models/activation_spec.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  expire_at  :datetime
-#  member_id  :integer
-#  is_used    :boolean
-#  type       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 require 'spec_helper'
 
 describe Activation do

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -1,16 +1,3 @@
-# == Schema Information
-#
-# Table name: api_tokens
-#
-#  id              :integer          not null, primary key
-#  member_id       :integer          not null
-#  access_key      :string(50)       not null
-#  secret_key      :string(50)       not null
-#  created_at      :datetime
-#  updated_at      :datetime
-#  trusted_ip_list :string(255)
-#
-
 require 'spec_helper'
 
 describe APIToken do

--- a/spec/models/audit/transfer_audit_log_spec.rb
+++ b/spec/models/audit/transfer_audit_log_spec.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: audit_logs
-#
-#  id             :integer          not null, primary key
-#  type           :string(255)
-#  operator_id    :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  auditable_id   :integer
-#  auditable_type :string(255)
-#  source_state   :string(255)
-#  target_state   :string(255)
-#
-
 require 'spec_helper'
 
 module Audit

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: comments
-#
-#  id         :integer          not null, primary key
-#  content    :text
-#  author_id  :integer
-#  ticket_id  :integer
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 require 'spec_helper'
 
 describe Comment do

--- a/spec/models/deposit_spec.rb
+++ b/spec/models/deposit_spec.rb
@@ -1,25 +1,3 @@
-# == Schema Information
-#
-# Table name: deposits
-#
-#  id         :integer          not null, primary key
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  txid       :string(255)
-#  state      :integer
-#  aasm_state :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  memo       :string(255)
-#  type       :string(255)
-#
-
 require 'spec_helper'
 
 describe Deposit do

--- a/spec/models/id_document_spec.rb
+++ b/spec/models/id_document_spec.rb
@@ -1,23 +1,3 @@
-# == Schema Information
-#
-# Table name: id_documents
-#
-#  id                 :integer          not null, primary key
-#  id_document_type   :integer
-#  name               :string(255)
-#  id_document_number :string(255)
-#  member_id          :integer
-#  created_at         :datetime
-#  updated_at         :datetime
-#  birth_date         :date
-#  address            :text
-#  city               :string(255)
-#  country            :string(255)
-#  zipcode            :string(255)
-#  id_bill_type       :integer
-#  aasm_state         :string(255)
-#
-
 require 'spec_helper'
 
 describe IdDocument do

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,19 +1,3 @@
-# == Schema Information
-#
-# Table name: identities
-#
-#  id              :integer          not null, primary key
-#  email           :string(255)
-#  password_digest :string(255)
-#  is_active       :boolean
-#  retry_count     :integer
-#  is_locked       :boolean
-#  locked_at       :datetime
-#  last_verify_at  :datetime
-#  created_at      :datetime
-#  updated_at      :datetime
-#
-
 require 'spec_helper'
 
 describe Identity do

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,25 +1,3 @@
-# == Schema Information
-#
-# Table name: members
-#
-#  id                    :integer          not null, primary key
-#  sn                    :string(255)
-#  display_name          :string(255)
-#  email                 :string(255)
-#  identity_id           :integer
-#  created_at            :datetime
-#  updated_at            :datetime
-#  state                 :integer
-#  activated             :boolean
-#  country_code          :integer
-#  phone_number          :string(255)
-#  phone_number_verified :boolean
-#  disabled              :boolean          default(FALSE)
-#  api_disabled          :boolean          default(FALSE)
-#  inviter_id            :integer
-#  referral_code_reward  :boolean          default(FALSE)
-#
-
 require 'spec_helper'
 
 describe Member do

--- a/spec/models/order_ask_spec.rb
+++ b/spec/models/order_ask_spec.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: orders
-#
-#  id             :integer          not null, primary key
-#  bid            :integer
-#  ask            :integer
-#  currency       :integer
-#  price          :decimal(32, 16)
-#  volume         :decimal(32, 16)
-#  origin_volume  :decimal(32, 16)
-#  state          :integer
-#  done_at        :datetime
-#  type           :string(8)
-#  member_id      :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  sn             :string(255)
-#  source         :string(255)      not null
-#  ord_type       :string(10)
-#  locked         :decimal(32, 16)
-#  origin_locked  :decimal(32, 16)
-#  funds_received :decimal(32, 16)  default(0.0)
-#
-
 require 'spec_helper'
 
 describe OrderAsk do

--- a/spec/models/order_bid_spec.rb
+++ b/spec/models/order_bid_spec.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: orders
-#
-#  id             :integer          not null, primary key
-#  bid            :integer
-#  ask            :integer
-#  currency       :integer
-#  price          :decimal(32, 16)
-#  volume         :decimal(32, 16)
-#  origin_volume  :decimal(32, 16)
-#  state          :integer
-#  done_at        :datetime
-#  type           :string(8)
-#  member_id      :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  sn             :string(255)
-#  source         :string(255)      not null
-#  ord_type       :string(10)
-#  locked         :decimal(32, 16)
-#  origin_locked  :decimal(32, 16)
-#  funds_received :decimal(32, 16)  default(0.0)
-#
-
 require 'spec_helper'
 
 describe OrderBid do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,28 +1,3 @@
-# == Schema Information
-#
-# Table name: orders
-#
-#  id             :integer          not null, primary key
-#  bid            :integer
-#  ask            :integer
-#  currency       :integer
-#  price          :decimal(32, 16)
-#  volume         :decimal(32, 16)
-#  origin_volume  :decimal(32, 16)
-#  state          :integer
-#  done_at        :datetime
-#  type           :string(8)
-#  member_id      :integer
-#  created_at     :datetime
-#  updated_at     :datetime
-#  sn             :string(255)
-#  source         :string(255)      not null
-#  ord_type       :string(10)
-#  locked         :decimal(32, 16)
-#  origin_locked  :decimal(32, 16)
-#  funds_received :decimal(32, 16)  default(0.0)
-#
-
 require 'spec_helper'
 
 describe Order, 'validations' do

--- a/spec/models/partial_tree_spec.rb
+++ b/spec/models/partial_tree_spec.rb
@@ -1,16 +1,3 @@
-# == Schema Information
-#
-# Table name: partial_trees
-#
-#  id         :integer          not null, primary key
-#  proof_id   :integer          not null
-#  account_id :integer          not null
-#  json       :text             not null
-#  created_at :datetime
-#  updated_at :datetime
-#  sum        :string(255)
-#
-
 require 'spec_helper'
 
 describe PartialTree do

--- a/spec/models/payment_address_spec.rb
+++ b/spec/models/payment_address_spec.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: payment_addresses
-#
-#  id         :integer          not null, primary key
-#  account_id :integer
-#  address    :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  currency   :integer
-#
-
 require 'spec_helper'
 
 describe PaymentAddress do

--- a/spec/models/payment_transaction_spec.rb
+++ b/spec/models/payment_transaction_spec.rb
@@ -1,21 +1,3 @@
-# == Schema Information
-#
-# Table name: payment_transactions
-#
-#  id            :integer          not null, primary key
-#  txid          :string(255)
-#  amount        :decimal(32, 16)
-#  confirmations :integer
-#  address       :string(255)
-#  state         :integer
-#  aasm_state    :string(255)
-#  created_at    :datetime
-#  updated_at    :datetime
-#  receive_at    :datetime
-#  dont_at       :datetime
-#  currency      :integer
-#
-
 require 'spec_helper'
 
 describe PaymentTransaction do

--- a/spec/models/proof_spec.rb
+++ b/spec/models/proof_spec.rb
@@ -1,18 +1,3 @@
-# == Schema Information
-#
-# Table name: proofs
-#
-#  id         :integer          not null, primary key
-#  root       :string(255)
-#  currency   :integer
-#  ready      :boolean          default(FALSE)
-#  created_at :datetime
-#  updated_at :datetime
-#  sum        :string(255)
-#  addresses  :text
-#  balance    :string(30)
-#
-
 require 'spec_helper'
 
 describe Proof do

--- a/spec/models/sms_token_spec.rb
+++ b/spec/models/sms_token_spec.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  expire_at  :datetime
-#  member_id  :integer
-#  is_used    :boolean
-#  type       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 require 'spec_helper'
 
 describe SmsToken do

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -1,16 +1,3 @@
-# == Schema Information
-#
-# Table name: tickets
-#
-#  id         :integer          not null, primary key
-#  title      :string(255)
-#  content    :text
-#  aasm_state :string(255)
-#  author_id  :integer
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 require 'spec_helper'
 
 describe Ticket do

--- a/spec/models/token_spec.rb
+++ b/spec/models/token_spec.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: tokens
-#
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  expire_at  :datetime
-#  member_id  :integer
-#  is_used    :boolean
-#  type       :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#
-
 require 'spec_helper'
 
 describe Token do

--- a/spec/models/trade_spec.rb
+++ b/spec/models/trade_spec.rb
@@ -1,21 +1,3 @@
-# == Schema Information
-#
-# Table name: trades
-#
-#  id            :integer          not null, primary key
-#  price         :decimal(32, 16)
-#  volume        :decimal(32, 16)
-#  ask_id        :integer
-#  bid_id        :integer
-#  trend         :integer
-#  currency      :integer
-#  created_at    :datetime
-#  updated_at    :datetime
-#  ask_member_id :integer
-#  bid_member_id :integer
-#  funds         :decimal(32, 16)
-#
-
 require 'spec_helper'
 
 describe Trade, ".latest_price" do

--- a/spec/models/two_factor_spec.rb
+++ b/spec/models/two_factor_spec.rb
@@ -1,15 +1,3 @@
-# == Schema Information
-#
-# Table name: two_factors
-#
-#  id             :integer          not null, primary key
-#  member_id      :integer
-#  otp_secret     :string(255)
-#  last_verify_at :datetime
-#  activated      :boolean
-#  type           :string(255)
-#
-
 require 'spec_helper'
 
 describe TwoFactor do

--- a/spec/models/withdraw_spec.rb
+++ b/spec/models/withdraw_spec.rb
@@ -1,26 +1,3 @@
-# == Schema Information
-#
-# Table name: withdraws
-#
-#  id         :integer          not null, primary key
-#  sn         :string(255)
-#  account_id :integer
-#  member_id  :integer
-#  currency   :integer
-#  amount     :decimal(32, 16)
-#  fee        :decimal(32, 16)
-#  fund_uid   :string(255)
-#  fund_extra :string(255)
-#  created_at :datetime
-#  updated_at :datetime
-#  done_at    :datetime
-#  txid       :string(255)
-#  aasm_state :string(255)
-#  sum        :decimal(32, 16)  default(0.0), not null
-#  type       :string(255)
-#  bsb        :string(255)
-#
-
 require 'spec_helper'
 
 describe Withdraw do


### PR DESCRIPTION
The annotations are too easy to out of sync with the actual DB structure.
This means it is likely a developer reading them from the file head could
get wrong information about the modal fields. We should read db/schema.rb
instead as that file is guaranteed to always updated.

We've already have multiple models with outdated annotations so I think it's more harmful to have this not so correct info than not having it at all.
