### PR TITLE
Update deploy-ubuntu.md

### DIFF
--- a/doc/deploy-ubuntu.md
+++ b/doc/deploy-ubuntu.md
@@ -219,7 +219,7 @@ More details to visit [pusher official website](http://pusher.com)
     TRADE_EXECUTOR=4 rake daemon:trade_executor:start
 
     # You can do the same when you start all daemons:
-    TRADE_EXECUTOR=4 rake daemon:start
+    TRADE_EXECUTOR=4 rake daemons:start
 
 **Passenger:**
 


### PR DESCRIPTION
Fixed a typo in the "Run Daemons" section of the deployment guide. If run as it was originally written, this error is encountered:

```
$ TRADE_EXECUTOR=4 rake daemon:start
rake aborted!
Don't know how to build task 'daemon:start'

(See full trace by running task with --trace)
```
