### PR TITLE
Update instructions for setting up Nginx

### DIFF
--- a/doc/deploy-ubuntu.md
+++ b/doc/deploy-ubuntu.md
@@ -144,6 +144,10 @@ Next, we need to update the Nginx configuration to point Passenger to the versio
 find the following lines, and uncomment them:
 
     passenger_root /usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini;
+    passenger_ruby /usr/bin/ruby;
+
+update the second line to read:
+
     passenger_ruby /home/deploy/.rbenv/shims/ruby;
 
 ### 8. Install JavaScript Runtime


### PR DESCRIPTION
It appears that the default Nginx setup has a line for:

```
passenger_ruby /usr/bin/ruby;
```

instead of:

```
passenger_ruby /home/deploy/.rbenv/shims/ruby;
```

This update adjusts the text of the setup instructions to point out that this needs to be uncommented **and** modified. If this change isn't made during setup you will see an error when you restart the Nginx service to start using Passenger.

```
deploy@exchange:~/peatio/current$ sudo service nginx restart
* Restarting nginx nginx                                                [fail]
```
