### PR TITLE
Fix "apt-add-repository not found"

### DIFF
--- a/doc/deploy-ubuntu.md
+++ b/doc/deploy-ubuntu.md
@@ -65,6 +65,7 @@ Install bundler
 
 Be sure to install the latest stable Redis, as the package in the distro may be a bit old:
 
+    sudo apt-get install python-software-properties
     sudo apt-add-repository -y ppa:rwky/redis
     sudo apt-get update
     sudo apt-get install redis-server


### PR DESCRIPTION
apt-add-repository is not available on vanilla Ubuntu install. It is provided by the python-software-properties package.
