### PR TITLE
add-apt-repository is provided by another package

### DIFF
--- a/doc/deploy-ubuntu.md
+++ b/doc/deploy-ubuntu.md
@@ -34,7 +34,7 @@ Installing [rbenv](https://github.com/sstephenson/rbenv) using a Installer
 
     sudo apt-get install git-core curl zlib1g-dev build-essential \
                          libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 \
-                         libxml2-dev libxslt1-dev libcurl4-openssl-dev python-software-properties
+                         libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common
 
     cd
     git clone git://github.com/sstephenson/rbenv.git .rbenv


### PR DESCRIPTION
add-apt-repository is provided by software-properties-common instead of python-software-properties in Ubuntu 14.04

``` bash
eploy@server2:~$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.1 LTS
Release:    14.04
Codename:   trusty
deploy@server2:~$ apt-file search add-apt-repository
software-properties-common: /usr/bin/add-apt-repository
software-properties-common: /usr/share/man/man1/add-apt-repository.1.gz
deploy@server2:~$
```
