### PR TITLE
README: fix typo (cuting-edge -> cutting-edge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 An open-source crypto currency exchange
 =====================================
 
-Peatio is a free and open-source crypto currency exchange implementation with the Rails framework and other cuting-edge technology.
+Peatio is a free and open-source crypto currency exchange implementation with the Rails framework and other cutting-edge technology.
 
 [![Code Climate](https://codeclimate.com/github/peatio/peatio.png)](https://codeclimate.com/github/peatio/peatio)
 [![Build Status](https://travis-ci.org/peatio/peatio.png?branch=master)](https://travis-ci.org/peatio/peatio)


### PR DESCRIPTION
This fixes a typo in the first sentence of the README.
