### PR TITLE
update json version to 1.8.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'daemons-rails'
 gem 'redis-rails'
 
 gem 'rotp'
-gem 'json'
+gem 'json', '~> 1.8.3'
 gem 'jbuilder'
 gem 'bcrypt-ruby', '~> 3.1.2'
 


### PR DESCRIPTION
Update json gem package version to 1.8.3 to avoid the install error with version 1.8.1